### PR TITLE
Improvement/implement limit query param

### DIFF
--- a/sorted_autocomplete_m2m/static/sorted-autocomplete-m2m/js/m2m.js
+++ b/sorted_autocomplete_m2m/static/sorted-autocomplete-m2m/js/m2m.js
@@ -129,6 +129,7 @@ if (typeof jQuery === 'undefined') {
             var field_name = main_container.attr('data-name')
             var autocomplete_input = main_container.find('input[data-autocomplete-url]')
             var autocomplete_url = autocomplete_input.attr('data-autocomplete-url')
+            var limit = autocomplete_input.attr('data-limit')
             var autocomplete_results = main_container.find('.autocomplete-results')
             var autocomplete_results_container = main_container.find('.autocomplete-results-container')
             var sorted_results = main_container.find('.sortedm2m-results')
@@ -147,7 +148,7 @@ if (typeof jQuery === 'undefined') {
                 }
                 clearTimeout(ajax_timeout)
                 ajax_timeout = setTimeout(function () {
-                    $.get(autocomplete_url, {q: q}, function (result) {
+                    $.get(autocomplete_url, {q: q, limit: limit}, function (result) {
                         var choices = result['choices']
                         if (choices) {
                             autocomplete_results.html('')

--- a/sorted_autocomplete_m2m/templates/sorted-autocomplete-m2m/m2m.html
+++ b/sorted_autocomplete_m2m/templates/sorted-autocomplete-m2m/m2m.html
@@ -1,6 +1,7 @@
 {% load i18n static %}
 <div class="sorted-autocomplete-m2m" data-name="{{ name }}">
     <p>
+        <img src="/static/sortedm2m/selector-search.gif" alt="" title="Type into this box to filter down the list.">
         <input data-autocomplete-url="{{ autocomplete_url }}" type="text"
                placeholder="{% trans "Filter" %}"/>
     </p>

--- a/sorted_autocomplete_m2m/templates/sorted-autocomplete-m2m/m2m.html
+++ b/sorted_autocomplete_m2m/templates/sorted-autocomplete-m2m/m2m.html
@@ -2,7 +2,7 @@
 <div class="sorted-autocomplete-m2m" data-name="{{ name }}">
     <p>
         <img src="/static/sortedm2m/selector-search.gif" alt="" title="Type into this box to filter down the list.">
-        <input data-autocomplete-url="{{ autocomplete_url }}" type="text"
+        <input data-autocomplete-url="{{ autocomplete_url }}" type="text" data-limit="{{ limit }}"
                placeholder="{% trans "Filter" %}"/>
     </p>
     <div class="autocomplete-results-container">

--- a/sorted_autocomplete_m2m/views.py
+++ b/sorted_autocomplete_m2m/views.py
@@ -4,6 +4,7 @@ __author__ = 'snake'
 
 
 def m2m_ajax(request, model, search_fields, limit=10):
+    limit = request.GET.get('limit') if request.GET.get('limit') is not None else limit
     q = request.GET.get('q')
     query_kwargs = {'%s__istartswith' % search_field: q for search_field in search_fields}
     qs = model.objects.filter(**query_kwargs).order_by(*search_fields)[:limit]

--- a/sorted_autocomplete_m2m/views.py
+++ b/sorted_autocomplete_m2m/views.py
@@ -4,7 +4,6 @@ __author__ = 'snake'
 
 
 def m2m_ajax(request, model, search_fields, limit=10):
-    limit = request.GET.get('limit') if request.GET.get('limit') is not None else limit
     q = request.GET.get('q')
     query_kwargs = {'%s__istartswith' % search_field: q for search_field in search_fields}
     qs = model.objects.filter(**query_kwargs).order_by(*search_fields)[:limit]

--- a/sorted_autocomplete_m2m/widgets.py
+++ b/sorted_autocomplete_m2m/widgets.py
@@ -23,12 +23,11 @@ class SuperSortWidget(SortedCheckboxSelectMultiple):
             'sorted-autocomplete-m2m/css/m2m.css',
         )}
 
-    def __init__(self, url_name:str, query_string:dict=None, **kwargs: Any):
+    def __init__(self, url_name:str, limit:int=10, **kwargs: Any):
         super().__init__(**kwargs)
 
         self.autocomplete_url = reverse_lazy(url_name) 
-        if query_string is not None:
-            self.autocomplete_url = self.autocomplete_url + '?' + urlencode(query_string)
+        self.limit = limit
 
     def filter_unselected_choices(self, value):
         if value is None:
@@ -42,6 +41,7 @@ class SuperSortWidget(SortedCheckboxSelectMultiple):
         return get_template('sorted-autocomplete-m2m/m2m.html').render({
             'autocomplete_id': '%s_autocomplete' % attrs['id'],
             'autocomplete_url': self.autocomplete_url,
+            'limit': self.limit,
             'selected': selected,
             'unselected': unselected,
             'name': name,

--- a/sorted_autocomplete_m2m/widgets.py
+++ b/sorted_autocomplete_m2m/widgets.py
@@ -7,7 +7,8 @@ from django.template.loader import get_template
 from django.utils.encoding import force_str
 from django.utils.html import conditional_escape
 from sortedm2m.forms import SortedMultipleChoiceField, SortedCheckboxSelectMultiple
-
+from urllib.parse import urlencode
+from typing import Any
 __author__ = 'snake'
 
 
@@ -22,9 +23,12 @@ class SuperSortWidget(SortedCheckboxSelectMultiple):
             'sorted-autocomplete-m2m/css/m2m.css',
         )}
 
-    def __init__(self, url_name, **kwargs):
+    def __init__(self, url_name:str, query_string:dict=None, **kwargs: Any):
         super().__init__(**kwargs)
-        self.autocomplete_url = reverse_lazy(url_name)
+
+        self.autocomplete_url = reverse_lazy(url_name) 
+        if query_string is not None:
+            self.autocomplete_url = self.autocomplete_url + '?' + urlencode(query_string)
 
     def filter_unselected_choices(self, value):
         if value is None:

--- a/sorted_autocomplete_m2m/widgets.py
+++ b/sorted_autocomplete_m2m/widgets.py
@@ -2,12 +2,10 @@ from itertools import chain
 from django import forms
 from django.urls import reverse_lazy
 from django.forms import Media
-from django.template import Context
 from django.template.loader import get_template
 from django.utils.encoding import force_str
 from django.utils.html import conditional_escape
 from sortedm2m.forms import SortedMultipleChoiceField, SortedCheckboxSelectMultiple
-from urllib.parse import urlencode
 from typing import Any
 __author__ = 'snake'
 


### PR DESCRIPTION
https://app.shortcut.com/boilerroom/story/12151/improve-many-to-many-selector

Adds the ability to specify a limit to the number of results returned for the Sorted M2M selector.


Defaults the limit to 10 if not passed. PR also adds a search Icon before the input field to mimic other searchable fields in Stash

<img width="746" alt="Screenshot 2023-09-11 at 16 28 35" src="https://github.com/boilerroomtv/django-sorted-autocomplete-m2m/assets/17564257/3e2e866b-8d14-4c13-b25f-64abb3a1261b">
